### PR TITLE
[CI] Refactor dependency mangement into a composite action and pin cmake version

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -1,0 +1,48 @@
+name: "Install build dependencies"
+description: "Installs all dependencies on all platforms that are generally required to compile Pylir"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install minimum required cmake and ninja
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: 3.20.6
+
+    - name: Install Ubuntu dependencies
+      if: ${{ contains(matrix.os, 'ubuntu') }}
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install libunwind-dev g++-10 lld clang
+
+    - name: Use MSVC developer command prompt
+      if: ${{ matrix.cxx_compiler == 'clang-cl' }}
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Install clang from MSYS2
+      uses: msys2/setup-msys2@v2
+      if: ${{ matrix.cxx_compiler == 'clang++' && contains(matrix.os, 'windows') }}
+      with:
+        msystem: clang64
+        update: true
+        pacboy: >-
+          toolchain:p
+        location: D:\
+
+    - name: Prepend Msys2 to path
+      shell: pwsh
+      if: ${{ matrix.cxx_compiler == 'clang++' && contains(matrix.os, 'windows') }}
+      run: echo "D:\msys64\clang64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+
+    - if: ${{ runner.os == 'Windows' }}
+      name: Use GNU tar for caching
+      shell: cmd
+      run: |
+        echo "Adding GNU tar to PATH"
+        echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -70,5 +70,5 @@ runs:
         ccache_options: |
           max_size=50M
           compiler_check=string:${{steps.compiler-hash.outputs.hash}}
-        override_cache_key: ${{input.ccache-key}}
+        override_cache_key: ${{inputs.ccache-key}}
         windows_compile_environment: msvc

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -1,6 +1,14 @@
 name: "Install build dependencies"
 description: "Installs all dependencies on all platforms that are generally required to compile Pylir"
 
+inputs:
+  cxx-compiler:
+    description: "C++ compiler that will be used for compilation"
+    required: true
+  ccache-key:
+    description: "Key to cache the ccache cache"
+    required: true
+
 runs:
   using: composite
   steps:
@@ -15,19 +23,19 @@ runs:
         cmakeVersion: 3.20.6
 
     - name: Install Ubuntu dependencies
-      if: ${{ contains(matrix.os, 'ubuntu') }}
+      if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
         sudo apt update
-        sudo apt install libunwind-dev g++-10 lld clang
+        sudo apt install libunwind-dev lld ${{inputs.cxx-compiler}}
 
     - name: Use MSVC developer command prompt
-      if: ${{ matrix.cxx_compiler == 'clang-cl' }}
+      if: ${{ inputs.cxx-compiler == 'clang-cl' }}
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Install clang from MSYS2
       uses: msys2/setup-msys2@v2
-      if: ${{ matrix.cxx_compiler == 'clang++' && contains(matrix.os, 'windows') }}
+      if: ${{ inputs.cxx-compiler == 'clang++' && runner.os == 'Windows' }}
       with:
         msystem: clang64
         update: true
@@ -37,7 +45,7 @@ runs:
 
     - name: Prepend Msys2 to path
       shell: pwsh
-      if: ${{ matrix.cxx_compiler == 'clang++' && contains(matrix.os, 'windows') }}
+      if: ${{ inputs.cxx-compiler == 'clang++' && runner.os == 'Windows' }}
       run: echo "D:\msys64\clang64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
 
     - if: ${{ runner.os == 'Windows' }}
@@ -46,3 +54,21 @@ runs:
       run: |
         echo "Adding GNU tar to PATH"
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+
+    - name: Generate compiler hash
+      id: compiler-hash
+      shell: pwsh
+      run: |
+        $compiler_version = ${{inputs.cxx-compiler}} -v 2>&1 | Out-String
+        $stream = [IO.MemoryStream]::new([byte[]][char[]]$compiler_version)
+        $hash = (Get-FileHash -InputStream $stream -Algorithm SHA256).Hash
+        "hash=$hash" >> $Env:GITHUB_OUTPUT
+
+    - name: Install CCache
+      uses: Chocobo1/setup-ccache-action@v1
+      with:
+        ccache_options: |
+          max_size=50M
+          compiler_check=string:${{steps.compiler-hash.outputs.hash}}
+        override_cache_key: ${{input.ccache-key}}
+        windows_compile_environment: msvc

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install libunwind-dev lld ${{inputs.cxx-compiler}}
+        sudo apt install libunwind-dev lld clang g++-10
 
     - name: Use MSVC developer command prompt
       if: ${{ inputs.cxx-compiler == 'clang-cl' }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -35,14 +35,13 @@ jobs:
         shell: pwsh
 
     steps:
-
-      - name: Install Dependencies
-        uses: ./Pylir/.github/actions/dependencies
-
       - name: Checkout Pylir
         uses: actions/checkout@v3
         with:
           path: Pylir
+
+      - name: Install Dependencies
+        uses: ./Pylir/.github/actions/dependencies
 
       - name: Install Python depends
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -40,38 +40,40 @@ jobs:
         with:
           path: Pylir
 
-      - name: Install Dependencies
-        uses: ./Pylir/.github/actions/dependencies
-
-      - name: Install Python depends
-        run: |
-          Invoke-expression "$Env:pythonLocation\python -m pip install -r ${{github.workspace}}/Pylir/test/requirements.txt"
-
       - name: Calculate cache key
         id: cache-key
         shell: pwsh
         run: |
           $key = '${{runner.os}}'
-          
+
           if ('${{matrix.sanitizer}}') {
             $key += '-${{matrix.sanitizer}}'.Replace(',', '_and_')
           }
-          
+
           if ('${{matrix.runtime_lib}}') {
             $key += '${{matrix.runtime_lib}}'
           }
-          
+
           $compiler_version = ${{matrix.cxx_compiler}} -v 2>&1 | Out-String
           $stream = [IO.MemoryStream]::new([byte[]][char[]]$compiler_version)
           $hash = (Get-FileHash -InputStream $stream -Algorithm SHA256).Hash
           $key += '-' + $hash
-          "compiler_check=string:$hash" >> $Env:GITHUB_OUTPUT
-          
+
           if ('${{matrix.shared_libs}}') {
             $key += '-shared'
           }
-          
+
           "key=$key" >> $Env:GITHUB_OUTPUT
+
+      - name: Install Dependencies
+        uses: ./Pylir/.github/actions/dependencies
+        with:
+          cxx-compiler: ${{matrix.cxx_compiler}}
+          ccache-key: ${{steps.cache-key.outputs.key}}
+
+      - name: Install Python depends
+        run: |
+          Invoke-expression "$Env:pythonLocation\python -m pip install -r ${{github.workspace}}/Pylir/test/requirements.txt"
 
       - name: Build LLVM
         id: llvm-build
@@ -83,15 +85,6 @@ jobs:
           runtime_lib: ${{matrix.runtime_lib}}
           shared_libs: ${{matrix.shared_libs}}
           cache-key: LLVM-${{steps.cache-key.outputs.key}}
-
-      - name: Install CCache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          ccache_options: |
-            max_size=50M
-            compiler_check=${{steps.cache-key.outputs.compiler_check}}
-          override_cache_key: ${{steps.cache-key.outputs.key}}
-          windows_compile_environment: msvc
 
       - name: Configure Pylir
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -36,44 +36,8 @@ jobs:
 
     steps:
 
-      - name: Install Ninja
-        uses: ashutoshvarma/setup-ninja@v1.1
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Install dependencies
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install libunwind-dev g++-10 lld clang
-
-      - name: Use developer command prompt
-        if: ${{ matrix.cxx_compiler == 'clang-cl' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - uses: msys2/setup-msys2@v2
-        if: ${{ matrix.cxx_compiler == 'clang++' && contains(matrix.os, 'windows') }}
-        with:
-          msystem: clang64
-          update: true
-          pacboy: >-
-            toolchain:p
-          location: D:\
-
-      - name: Prepend Msys2 to path
-        if: ${{ matrix.cxx_compiler == 'clang++' && contains(matrix.os, 'windows') }}
-        run: echo "D:\msys64\clang64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-
-      - if: ${{ runner.os == 'Windows' }}
-        name: Use GNU tar for caching
-        shell: cmd
-        run: |
-          echo "Adding GNU tar to PATH"
-          echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+      - name: Install Dependencies
+        uses: ./Pylir/.github/actions/dependencies
 
       - name: Checkout Pylir
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
+      - name: Install clang-tidy
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh $LLVM_VERSION all
+
       - name: Checkout Pylir
         uses: actions/checkout@v3
         with:
@@ -29,12 +35,6 @@ jobs:
         with:
           cxx-compiler: clang++
           ccache-key: clang-tidy
-
-      - name: Install clang-tidy
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh $LLVM_VERSION all
 
       # Required by clang-tidy-diff.py.
       - name: Install Python depends

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,28 +15,20 @@ env:
 jobs:
   lint-run:
     runs-on: ubuntu-22.04
-
     steps:
-      - name: Install dependencies
+      - name: Install Dependencies
+        uses: ./Pylir/.github/actions/dependencies
+
+      - name: Install clang-tidy
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh $LLVM_VERSION all
-          sudo apt update
-          sudo apt install libunwind-dev lld
-          
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
 
       # Required by clang-tidy-diff.py.
       - name: Install Python depends
         run: |
           python -m pip install pyyaml
-
-      - name: Install Ninja
-        uses: ashutoshvarma/setup-ninja@v1.1
 
       - name: Checkout Pylir
         uses: actions/checkout@v3
@@ -66,7 +58,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_C_COMPILER=clang \
-            -DPython3_EXECUTABLE="$(which python)" \
+            -DPython3_ROOT_DIR="$pythonLocation" \
+            -DPython3_FIND_STRATEGY=LOCATION \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,14 @@ jobs:
   lint-run:
     runs-on: ubuntu-22.04
     steps:
+
+      - name: Checkout Pylir
+        uses: actions/checkout@v3
+        with:
+          path: Pylir
+          # Depth 2 because we use git diff HEAD^ later.
+          fetch-depth: 2
+
       - name: Install Dependencies
         uses: ./Pylir/.github/actions/dependencies
 
@@ -29,13 +37,6 @@ jobs:
       - name: Install Python depends
         run: |
           python -m pip install pyyaml
-
-      - name: Checkout Pylir
-        uses: actions/checkout@v3
-        with:
-          path: Pylir
-          # Depth 2 because we use git diff HEAD^ later.
-          fetch-depth: 2
 
       - name: Build LLVM
         id: llvm-build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Dependencies
         uses: ./Pylir/.github/actions/dependencies
         with:
-          cxx_compiler: clang++
+          cxx-compiler: clang++
           ccache-key: clang-tidy
 
       - name: Install clang-tidy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Install Dependencies
         uses: ./Pylir/.github/actions/dependencies
+        with:
+          cxx_compiler: clang++
+          ccache-key: clang-tidy
 
       - name: Install clang-tidy
         run: |
@@ -45,13 +48,6 @@ jobs:
           c-compiler: clang
           cpp-compiler: clang++
           cache-key: clang-tidy
-
-      - name: Install CCache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          ccache_options: |
-            max_size=50M
-          override_cache_key: ${{runner.os}}-clang-tidy
 
       - name: Configure Pylir
         run: |


### PR DESCRIPTION
CMake version will be the minimum required cmake verison in the future. 
3.20 is chosen as that is likely going to be LLVMs requirement in the near future as well