### PR TITLE
[PylirToLLVM] Remove incorrect `noalias` attribute on `pylir_gc_alloc`

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
@@ -93,7 +93,7 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc, mlir::OpB
             returnType = m_objectPtrType;
             argumentTypes = {m_typeConverter.getIndexType()};
             functionName = "pylir_gc_alloc";
-            resultAttrs.append(mlir::LLVM::LLVMDialect::getNoAliasAttrName(), mlir::UnitAttr::get(context));
+            // TODO: Set allockind("alloc,zeroed") allocsize(0) LLVM attributes once supported upstream.
             break;
         case Runtime::mp_init_u64:
             returnType = mlir::LLVM::LLVMVoidType::get(context);

--- a/test/Optimizer/Conversion/PylirToLLVM/gcAllocObjectsOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/gcAllocObjectsOp.mlir
@@ -31,9 +31,9 @@ py.func @foo() -> !pyMem.memory {
 // CHECK-NEXT: llvm.store %[[STR]], %[[GEP]] {tbaa = [#[[$PYTHON_TYPE_OBJECT]]]}
 // CHECK-NEXT: llvm.return %[[MEMORY]]
 
-// CHECK: llvm.func @pylir_gc_alloc(i{{[0-9]+}}) -> (!llvm.ptr<{{[0-9]+}}> {
-// CHECK-SAME: llvm.noalias
-// CHECK-SAME: }) attributes
+// CHECK: llvm.func @pylir_gc_alloc
+// CHECK-NOT: llvm.noalias
+// CHECK-SAME: attributes
 
 // -----
 


### PR DESCRIPTION
The `noalias` attribute on return types of functions has additional special semantics in LLVM. According to the LangRef, it makes LLVM assume that the pointer returned by the function is unique AND that it comes from the system allocator directly.

The latter has bad consequences in our case however. It makes LLVM assume that stores to the objects memory that are not read are dead and can be removed. This is incorrect in our case however as the GC relies on code setting the type object and attempts reading it. LLVM deleting the store of the type object however leads to it remaining null, and the GC crashing when trying to parse the heap during garbage collection.

As an alternative, LLVM supports the `allockind` attribute which informs it that the function comes from a system allocator. It is currently not nicely modelled in MLIRs LLVM Dialect however and left for a future PR