### PR TITLE
[docs] Treat warnings as errors

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_target(create-build-dir
         COMMENT "Copying docs sources")
 
 add_custom_target(docs
-        ${SPHINX_EXECUTABLE} -b html . build
+        ${SPHINX_EXECUTABLE} -b html . build -W --keep-going -n
         COMMENT "Building Sphinx docs"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(docs PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/build")


### PR DESCRIPTION
This way if the docs were to emit any errors, the CI should fail instead of silently creating issues.

Note that in the C++ world, treating warnings as errors is somewhat of an anti-pattern. This is because newer compiler versions often introduce new warnings, breaking the use of newer toolchains. The hope is that this is not as problematic in Sphinx due to 1) the sphinx version being locked in the requirements file and 2) there not being a lot of warnings and tendency for false-positives or opinionated code