### PR TITLE
[test] Remove `-O3` from execution tests

### DIFF
--- a/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
+++ b/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
@@ -88,8 +88,8 @@ void mark(std::uintptr_t stackLowerBound, std::uintptr_t stackUpperBound, std::v
                          [&](pylir::rt::PyObject* subObject)
                          {
                              auto address = reinterpret_cast<std::uintptr_t>(subObject);
-                             if ((address >= stackLowerBound && address <= stackUpperBound) || isGlobal(subObject)
-                                 || subObject->getMark<bool>())
+                             if (!address || (address >= stackLowerBound && address <= stackUpperBound)
+                                 || isGlobal(subObject) || subObject->getMark<bool>())
                              {
                                  return;
                              }

--- a/test/Execution/Dataflow.py
+++ b/test/Execution/Dataflow.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 def foo(x):

--- a/test/Execution/HelloWorld.py
+++ b/test/Execution/HelloWorld.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s
 print("Hello World!")
 # CHECK: Hello World!

--- a/test/Execution/NameError.py
+++ b/test/Execution/NameError.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: not %t 2>&1 | FileCheck %s
 
 a

--- a/test/Execution/SSA-Bug.py
+++ b/test/Execution/SSA-Bug.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 def random():

--- a/test/Execution/attributes.py
+++ b/test/Execution/attributes.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 obj = object()

--- a/test/Execution/aug_ops.py
+++ b/test/Execution/aug_ops.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 i = 5

--- a/test/Execution/bool.py
+++ b/test/Execution/bool.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(True)

--- a/test/Execution/catch.py
+++ b/test/Execution/catch.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s
 
 def foo():

--- a/test/Execution/comparison.py
+++ b/test/Execution/comparison.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(object() == object())

--- a/test/Execution/contains.py
+++ b/test/Execution/contains.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 d = {"one": 1, "two": 2, "five": 5}

--- a/test/Execution/for.py
+++ b/test/Execution/for.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 for i in (3, 5, 6):

--- a/test/Execution/hash.py
+++ b/test/Execution/hash.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(hash(5) == hash(5))

--- a/test/Execution/if.py
+++ b/test/Execution/if.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 if True:

--- a/test/Execution/int.py
+++ b/test/Execution/int.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 print(420)
 # CHECK: 420

--- a/test/Execution/isinstance.py
+++ b/test/Execution/isinstance.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(isinstance(5, int))

--- a/test/Execution/iter.py
+++ b/test/Execution/iter.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 it = iter((3, 5, 6))

--- a/test/Execution/lambda.py
+++ b/test/Execution/lambda.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 

--- a/test/Execution/len.py
+++ b/test/Execution/len.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(len(()))

--- a/test/Execution/nested.py
+++ b/test/Execution/nested.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 

--- a/test/Execution/print.py
+++ b/test/Execution/print.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 print("text")
 # CHECK: text

--- a/test/Execution/raise.py
+++ b/test/Execution/raise.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 try:

--- a/test/Execution/repr.py
+++ b/test/Execution/repr.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(repr(420) == "420")

--- a/test/Execution/str.py
+++ b/test/Execution/str.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print("Hello" + " " + "World")

--- a/test/Execution/tuple.py
+++ b/test/Execution/tuple.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print((3, 353))

--- a/test/Execution/type.py
+++ b/test/Execution/type.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(type(0) == int)

--- a/test/Execution/unpack-assign.py
+++ b/test/Execution/unpack-assign.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 a = 3

--- a/test/Execution/while.py
+++ b/test/Execution/while.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t -O3
+# RUN: pylir %rt_link_flags %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 while False:


### PR DESCRIPTION
This was originally added as I found it "useful", to essentially stress test the optimizer pipeline. This remains true, but is the wrong approach. The -O3 heavily impacts testing times and generates "test-coverage" from the wrong place. Rather, the tests in Execution test 1) the implementation in `src/python` and 2) integration with the compiler.

Arguably this should be split in the future. For now remove `-O3` to heavily reduce test time. Future changes enabled by this PR can then:
- add a nightly in the pipeline that does use -O3 to stress test it without impacting iteration time and PR merge time
- compile these python files with `pylir` as part of the cmake build process

Tiny note: a bug in the GC was found and is fixed here as well. Our runtime testing infrastructure is currently too lacking to easily add a regression test however...