### PR TITLE
[docs] Fix stateful build

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,16 +1,27 @@
+#  Licensed under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 find_program(SPHINX_EXECUTABLE NAMES sphinx-build REQUIRED)
 
 set(PYLIR_PREPROCESS_MLIR_MD "${CMAKE_CURRENT_SOURCE_DIR}/preprocess_mlir_md.py" PARENT_SCOPE)
 
+# Delete the source directory as there may be leftover files from previous copies.
+# Copy over the files in this directory and the preprocessed TableGen output afterwards.
 add_custom_target(create-build-dir
-        COMMAND "${CMAKE_COMMAND}" -E copy_directory
-        "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
-        COMMENT "Copying docs sources")
+  "${CMAKE_COMMAND}" -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/source"
+  COMMAND "${CMAKE_COMMAND}" -E copy_directory
+  "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/source"
+  COMMAND "${CMAKE_COMMAND}" -E copy_directory
+  "${CMAKE_CURRENT_BINARY_DIR}/TableGen" "${CMAKE_CURRENT_BINARY_DIR}/source/TableGen"
+  COMMENT "Copying docs sources")
+set_target_properties(create-build-dir PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/source")
+
+add_dependencies(create-build-dir mlir-doc)
 
 add_custom_target(docs
-        ${SPHINX_EXECUTABLE} -b html . build -W --keep-going -n
-        COMMENT "Building Sphinx docs"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  ${SPHINX_EXECUTABLE} -b html . ../build -W --keep-going -n
+  COMMENT "Building Sphinx docs"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/source)
 set_target_properties(docs PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/build")
-add_dependencies(docs create-build-dir mlir-doc)
+add_dependencies(docs create-build-dir)

--- a/docs/preprocess_mlir_md.py
+++ b/docs/preprocess_mlir_md.py
@@ -3,6 +3,7 @@
 #  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
+from pathlib import Path
 import re
 from functools import reduce
 from typing import Callable
@@ -26,7 +27,9 @@ class RegexReplaceFile:
         reg = reduce(lambda curr, r: curr + f'|({r[0]})', self.actions[1:], f'({self.actions[0][0]})') if len(
             self.actions) > 0 else ''
 
-        with open(self.output_path, 'w') as out:
+        p = Path(self.output_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open('w') as out:
             last_pos = 0
             for i in re.finditer(reg, self.input_string, flags=re.MULTILINE):
                 out.write(self.input_string[last_pos:i.start()])


### PR DESCRIPTION
Building the docs would often create errors due to files from previous builds remaining in the created source directory. This commit fixes that by always creating the source directory anew.

Ideally we'd not have to create a source directory for the docs using cmake but use the in-repo sources. This is currently impossible however as part of our sources are auto-generated and sphinx only supports a single root directory for its sources.