### PR TITLE
[Main] Remove support for TSAN instrumentation

### DIFF
--- a/test/Main/sanitizer-passes.py
+++ b/test/Main/sanitizer-passes.py
@@ -1,15 +1,10 @@
 # RUN: pylir %s -S -emit-llvm -o %t -Xprint-pipeline -Xsanitize-codegen -Xsanitize=address 2>&1 \
 # RUN: | FileCheck %s --check-prefix=ASAN-PIPE
 # RUN: cat %t | FileCheck %s --check-prefixes=ASAN-ATTR,CHECK
-# RUN: pylir %s -S -emit-llvm -o %t -Xprint-pipeline -Xsanitize-codegen -Xsanitize=thread 2>&1 \
-# RUN: | FileCheck %s --check-prefix=TSAN-PIPE
-# RUN: cat %t | FileCheck %s --check-prefixes=TSAN-ATTR,CHECK
 
 # ASAN-PIPE: AddressSanitizerPass<>,require<GlobalsAA>
-# TSAN-PIPE: ModuleThreadSanitizerPass,function(ThreadSanitizerPass),require<GlobalsAA>
 
 # CHECK: define {{.*}} @{{.*}}({{.*}}) #[[ATTR:[0-9]+]]
 
 # CHECK: #[[ATTR]] = {
 # ASAN-ATTR-SAME: sanitize_address
-# TSAN-ATTR-SAME: sanitize_thread


### PR DESCRIPTION
The upstream TSAN instrumentation recently broke for any pointers that are not the default address space. Additionally, it turns out that since https://github.com/llvm/llvm-project/commit/644d9d3a441fe115343a2ab498aa4210b6858ed6, these instrumentions only partially work on pointers with non-default address spaces.

Until this is fixed upstream, and to unblock the LLVM version bump, remove the support for TSAN. TSAN is very very low priority, but ASAN would be very useful to have working for debugging the GC.