### PR TITLE
[Py] Remove `SetAttr`

### DIFF
--- a/src/pylir/CodeGen/PyBuilder.hpp
+++ b/src/pylir/CodeGen/PyBuilder.hpp
@@ -102,11 +102,6 @@ public:
         return Py::DictAttr::get(getContext(), value);
     }
 
-    Py::SetAttr getSetAttr(llvm::ArrayRef<mlir::Attribute> value = {})
-    {
-        return Py::SetAttr::get(getContext(), value);
-    }
-
     Py::FunctionAttr getFunctionAttr(mlir::FlatSymbolRefAttr value, mlir::Attribute qualName = {},
                                      mlir::Attribute defaults = {}, mlir::Attribute kwDefaults = {},
                                      mlir::Attribute dict = {})

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
@@ -149,18 +149,6 @@ def PylirPy_ListAttr : TypeObjectSlotsAttr<"List",
 	let assemblyFormat = "`<` $value ( `,` struct($type_object, $slots)^)? `>`";
 }
 
-def PylirPy_SetAttr : TypeObjectSlotsAttr<"Set",
-	[ParamSpec<ListPrint<"::mlir::Attribute", "Braces">, "value", "{}">], [], [{
-		std::vector<mlir::Attribute> temp = value.vec();
-        temp.erase(std::unique(temp.begin(), temp.end()), temp.end());
-		value = temp;
-	}]> {
-	let mnemonic = "set";
-	let summary = "python set";
-
-	let assemblyFormat = "`<` $value ( `,` struct($type_object, $slots)^)? `>`";
-}
-
 def PylirPy_DictAttr : PylirPy_Attr<"Dict", [ObjectAttrInterface,
     DeclareAttrInterfaceMethods<SROAAttrInterface>]> {
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpFold.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpFold.cpp
@@ -43,7 +43,7 @@ struct TupleExpansionRemover : mlir::OpRewritePattern<T>
                              {
                                  // TODO: StringAttr
                                  return constant.getConstant()
-                                     .template isa<pylir::Py::ListAttr, pylir::Py::TupleAttr, pylir::Py::SetAttr>();
+                                     .template isa<pylir::Py::ListAttr, pylir::Py::TupleAttr>();
                              }
                              return mlir::isa<pylir::Py::MakeTupleOp, pylir::Py::MakeTupleExOp>(definingOp);
                          }));
@@ -74,7 +74,7 @@ protected:
                     [&](pylir::Py::ConstantOp constant)
                     {
                         llvm::TypeSwitch<mlir::Attribute>(constant.getConstant())
-                            .Case<pylir::Py::ListAttr, pylir::Py::SetAttr, pylir::Py::TupleAttr>(
+                            .Case<pylir::Py::ListAttr, pylir::Py::TupleAttr>(
                                 [&](auto attr)
                                 {
                                     auto values = attr.getValue();
@@ -339,7 +339,7 @@ std::optional<Attr> doConstantIterExpansion(llvm::ArrayRef<::mlir::Attribute> op
         }
         begin++;
         if (!llvm::TypeSwitch<mlir::Attribute, bool>(pair.value())
-                 .Case<pylir::Py::TupleAttr, pylir::Py::ListAttr, pylir::Py::SetAttr>(
+                 .Case<pylir::Py::TupleAttr, pylir::Py::ListAttr>(
                      [&](auto attr)
                      {
                          result.insert(result.end(), attr.getValue().begin(), attr.getValue().end());

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpSROA.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpSROA.cpp
@@ -343,13 +343,6 @@ void pylir::Py::ListAttr::destructureAggregate(
     }
 }
 
-void pylir::Py::SetAttr::destructureAggregate(
-    llvm::function_ref<void(mlir::Attribute, mlir::SideEffects::Resource*, mlir::Type, mlir::Attribute)> write) const
-{
-    destructureSlots(*this, write);
-    // TODO: Support SetAttr
-}
-
 void pylir::Py::DictAttr::destructureAggregate(
     llvm::function_ref<void(mlir::Attribute, mlir::SideEffects::Resource*, mlir::Type, mlir::Attribute)> write) const
 {

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpsVerifier.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpsVerifier.cpp
@@ -61,7 +61,7 @@ mlir::LogicalResult verify(mlir::Operation* op, mlir::Attribute attribute, mlir:
         }
     }
     return llvm::TypeSwitch<mlir::Attribute, mlir::LogicalResult>(object)
-        .Case<pylir::Py::TupleAttr, pylir::Py::SetAttr, pylir::Py::ListAttr>(
+        .Case<pylir::Py::TupleAttr, pylir::Py::ListAttr>(
             [&](auto sequence)
             {
                 for (auto iter : sequence.getValue())

--- a/test/Optimizer/PylirPy/IR/constant.mlir
+++ b/test/Optimizer/PylirPy/IR/constant.mlir
@@ -59,13 +59,6 @@ py.func @test_constant_tuple() -> !py.dynamic {
     return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_set
-py.func @test_constant_set() -> !py.dynamic {
-    %0 = constant(#py.set<{#py.float<433.4>, #py.int<5>}>)
-    %empty = constant(#py.set<{}>)
-    return %0 : !py.dynamic
-}
-
 // CHECK-LABEL: test_constant_dict
 py.func @test_constant_dict() -> !py.dynamic {
     %0 = constant(#py.dict<{#py.float<433.4> to #py.int<5>, #py.str<"__call__"> to #py.int<5>}>)


### PR DESCRIPTION
`SetAttr` is currently not tested properly at all and keeping it around in a half-implemented way does more harm than good. Remove it until it is properly implemented.