### PR TITLE
[ci] Workaround GitHub Runner MSVC version

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -53,7 +53,7 @@ runs:
       if: ${{ inputs.cpp-compiler == 'clang-cl' }}
       uses: ilammy/msvc-dev-cmd@v1
       with:
-        toolset: 14.36
+        toolset: 14.37
 
     - name: Install clang from MSYS2
       uses: msys2/setup-msys2@v2

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -52,6 +52,8 @@ runs:
     - name: Use MSVC developer command prompt
       if: ${{ inputs.cpp-compiler == 'clang-cl' }}
       uses: ilammy/msvc-dev-cmd@v1
+      with:
+        toolset: 14.36
 
     - name: Install clang from MSYS2
       uses: msys2/setup-msys2@v2


### PR DESCRIPTION
The latest GitHub runner image 20230903.2.0 shipped by GitHub for unknown reasons seemingly breaks MSVC debug builds. https://github.com/actions/runner-images/issues/8259 and the fact that the previous image used a newer MSVC version than this one, suggest that the MSVC installation is currently broken. This sadly leads to the MultiThreadedDebug CI to be broken completely, making all builds fail.

Try and workaround this issue by explicitly using the same toolset version from the previous runner-image in hope of it working.