### PR TITLE
[Runtime] Decrease initialization priority of `gc`

### DIFF
--- a/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
+++ b/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
@@ -8,8 +8,8 @@
 #include <pylir/Runtime/GC/Stack.hpp>
 #include <pylir/Support/Util.hpp>
 
-// Anything below 65535 would do basically
-pylir::rt::MarkAndSweep pylir::rt::gc __attribute__((init_priority(200)));
+// Anything below 65535 would do basically as compiler generated initializers have priority 65534.
+pylir::rt::MarkAndSweep pylir::rt::gc __attribute__((init_priority(65534)));
 
 pylir::rt::PyObject* pylir::rt::MarkAndSweep::alloc(std::size_t count)
 {


### PR DESCRIPTION
A recent change in MSVCs debug library is incompatible with the very low priority we set causing all executables to crash on exit. This happens due to initialization and deinitialization/destruction order causing undefined behaviour as objects are accessed in unsafe manners.

We will likely want to consider initializing `gc` and others in `main` in the future, to avoid any such issues.