### PR TITLE
[cmake] Add warning if found LLVM has a different revision

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -169,7 +169,7 @@ jobs:
           $use_lld `
           -DLLVM_BUILD_LLVM_C_DYLIB=OFF `
           -DLLVM_INCLUDE_BENCHMARKS=OFF `
-          -DLLVM_APPEND_VC_REV=OFF `
+          -DLLVM_APPEND_VC_REV=ON `
           -DLLD_BUILD_TOOLS=OFF `
           -DPython3_ROOT_DIR="$Env:pythonLocation" -DPython3_FIND_STRATEGY=LOCATION `
           $san_flag `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,26 @@ find_package(LLD REQUIRED)
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/.pinned-llvm-revision PYLIR_REQUIRED_LLVM_REVISION)
+string(STRIP ${PYLIR_REQUIRED_LLVM_REVISION} PYLIR_REQUIRED_LLVM_REVISION)
+
+find_file(VCS_HEADER VCSRevision.h PATHS ${LLVM_INCLUDE_DIRS} PATH_SUFFIXES llvm/Support/ REQUIRED NO_DEFAULT_PATH)
+message(STATUS "Checking ${VCS_HEADER} for version mismatch")
+file(READ ${VCS_HEADER} VCS_FILE)
+string(REGEX MATCH "#define LLVM_REVISION \"([a-z0-9]+)\"" VCS_MATCH ${VCS_FILE})
+if (CMAKE_MATCH_COUNT EQUAL 0)
+    message(WARNING "Failed to determine revision of LLVM installed. Proceed with caution.
+Required revision: ${PYLIR_REQUIRED_LLVM_REVISION}
+Found LLVM installation: ${MLIR_DIR}")
+else ()
+    if (NOT ${CMAKE_MATCH_1} STREQUAL PYLIR_REQUIRED_LLVM_REVISION)
+        message(WARNING "Installed LLVM revision (${CMAKE_MATCH_1}) does not match required revision.\
+        Compilation is likely to fail.
+Required revision: ${PYLIR_REQUIRED_LLVM_REVISION}
+Found LLVM installation: ${MLIR_DIR}")
+    endif ()
+endif ()
+
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
A version mismatch is a comparatively hard to find issue. Ideally, it'd simply be a build break but in worse cases it might even be a runtime error. Either way, thinking of checking the LLVM version and then manually comparing the revisions of both required and installed is a hassle. This commit therefore adds some logic to CMake to verify the revision found with the revision required, displaying a clear warning if mismatched.